### PR TITLE
fix: include nwid in ZeroTier controller settings

### DIFF
--- a/clanServices/zerotier/tests/eval-tests.nix
+++ b/clanServices/zerotier/tests/eval-tests.nix
@@ -107,6 +107,14 @@ in
       enabled = true;
     };
   };
+  test_controller_network_nwid = {
+    expr =
+      let
+        cfg = testFlake.nixosConfigurations.bam.config.clan.core.networking.zerotier;
+      in
+      cfg.settings.nwid == cfg.settings.id;
+    expected = true;
+  };
   test_generator_defined = {
     expr = {
       hasSharedGenerator =

--- a/nixosModules/clanCore/zerotier/default.nix
+++ b/nixosModules/clanCore/zerotier/default.nix
@@ -330,6 +330,7 @@ in
         mtu = 2800;
         multicastLimit = 32;
         name = cfg.name;
+        nwid = networkId;
         uwid = networkId;
         objtype = "network";
         private = !cfg.controller.public;


### PR DESCRIPTION
Add nwid to the generated ZeroTier controller network settings so the declarative network JSON matches the ZeroTier controller API schema.\n\nThis keeps the existing id and uwid fields unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected ZeroTier controller network configuration to explicitly include the network ID field in generated settings.

* **Tests**
  * Added validation test for ZeroTier controller network configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->