### PR TITLE
fix: `nix flake metadata`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -49,7 +49,9 @@
         ;
 
       privateInputs =
-        if builtins.pathExists (./. + "/.skip-private-inputs") then
+        if builtins.pathExists (./. + "/.skip-private-inputs")
+        || !builtins.pathExists ./.git
+        then
           { }
         else
           (import ./devFlake/flake-compat.nix {


### PR DESCRIPTION
clan-core is importing private inputs during flake evaluation even when it’s being fetched remotely, which makes `nix flake metadata` fail

fetched sources won’t have a `.git` directory, so private inputs are skipped there, while local working-tree checkouts still keep the existing behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved development environment configuration logic for handling private inputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/clan-lol/clan-core/pull/17?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->